### PR TITLE
fix: small circle intersection solution selection

### DIFF
--- a/src/smallCircleGreatCircleIntersection.spec.ts
+++ b/src/smallCircleGreatCircleIntersection.spec.ts
@@ -52,6 +52,19 @@ describe('smallCircleGreatCircleIntersection', () => {
         expect(intersection2!.long).toBeGreaterThan(0.99);
         expect(intersection2!.long).toBeLessThan(1.01);
     });
+    it('Check that first intercept from inside the circle finds the right solution', () => {
+        // this is a real case for an FD leg on the SEMC MSV1A departure that was broken
+        const intersection = firstSmallCircleIntersection({
+            lat: -2.257444381713867,
+            long: -78.110107421875,
+        }, 8.002046984678726, {
+            lat: -2.257444381713867,
+            long: -78.110107421875,
+        }, 25.967487812042236);
+        expect(intersection).not.toBeNull();
+        expect(intersection!.lat).toBeCloseTo(-2.137755053754944, 2);
+        expect(intersection!.long).toBeCloseTo(-78.05177509032232, 2);
+    });
     it('Check that the first intercept is returned when east of the circle', () => {
         const intersection1 = firstSmallCircleIntersection({
             lat: 0,

--- a/src/smallCircleGreatCircleIntersection.ts
+++ b/src/smallCircleGreatCircleIntersection.ts
@@ -159,11 +159,11 @@ export function firstSmallCircleIntersection(
 
     if (distanceTo(greatCircleReference, smallCircleCentre) <= smallCircleRadius) {
         // The great circle reference is inside the circle, use the intercept which is in-front of the great circle reference as per the great circle bearing
-        if (diffAngle(greatCircleBearing, bearingTo(greatCircleReference, intercepts[0])) <= 90) {
+        if (Math.abs(diffAngle(greatCircleBearing, bearingTo(greatCircleReference, intercepts[0]))) <= 90) {
             return intercepts[0];
         }
         return intercepts[1];
-    } if (diffAngle(greatCircleBearing, bearingTo(greatCircleReference, smallCircleCentre)) <= 90) {
+    } if (Math.abs(diffAngle(greatCircleBearing, bearingTo(greatCircleReference, smallCircleCentre))) <= 90) {
         // The small circle centre is in-front of the great circle reference, use the closest intercept
         if (distanceTo(greatCircleReference, intercepts[0]) < distanceTo(greatCircleReference, intercepts[1])) {
             return intercepts[0];


### PR DESCRIPTION
The test is a real case on an FD leg that was choosing the wrong solution in the A32NX, from the SEMC MSV1A departure. The test fails without the changes in this PR, and passes with.